### PR TITLE
[Feat] load balancer implementation

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "semi": false,
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "arrowParens": "avoid"
 }

--- a/load-balancer.ts
+++ b/load-balancer.ts
@@ -1,1 +1,63 @@
-console.log('hello chris')
+import http from 'http'
+
+interface BackendInstance {
+  host: string
+  port: number
+  name: string
+}
+
+/*** TODO: replace with ec2 instances ***/
+const clusters: BackendInstance[] = [
+  { host: 'localhost', port: 8081, name: 'Instance 1' },
+  { host: 'localhost', port: 8082, name: 'Instance 2' },
+  { host: 'localhost', port: 8083, name: 'Instance 3' },
+]
+
+/*** Intialize test servers for testing load-balancer ***/
+// TODO: remove once fully tested
+clusters.forEach(serverNode => {
+  http
+    .createServer((req, res) => {
+      console.log(`${serverNode.name} received request ${req.url}`)
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end(
+        `${serverNode.name}:${serverNode.port} is serving Request: ${req.url}`,
+      )
+    })
+    .listen(serverNode.port, () => {
+      console.log(`${serverNode.name} listening on port ${serverNode.port}`)
+    })
+})
+
+let currentServerPosition = 0
+const loadBalancer = http.createServer((req, res) => {
+  // Round-Robin Implementation
+  const server = clusters[currentServerPosition]
+  currentServerPosition = (currentServerPosition + 1) % clusters.length
+
+  console.log(`Load-Balancer forwarding request to ${server.name}`)
+  const proxyReq = http.request(
+    {
+      host: server.host,
+      port: server.port,
+      path: req.url,
+      method: req.method,
+      headers: req.headers,
+    },
+    proxyRes => {
+      res.writeHead(proxyRes.statusCode || 500, proxyRes.headers)
+      proxyRes.pipe(res)
+    },
+  )
+
+  req.pipe(proxyReq)
+  proxyReq.on('error', err => {
+    console.error(`Error connecting to ${server.name}:`, err)
+    res.writeHead(500, { 'Content-Type': 'text/plain' })
+    res.end('Internal Server Error')
+  })
+})
+
+loadBalancer.listen(8080, () => {
+  console.log('Load Balancer on Port 8080')
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,9 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
     /* Projects */
     /* Language and Environment */
-    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     /* Modules */
-    "module": "ESNext" /* Specify what module code is generated. */,
+    "module": "CommonJS" /* Specify what module code is generated. */,
     /* Interop Constraints */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,


### PR DESCRIPTION
load-balancer.ts
* Created a simple Load-Balancer with a `http.createServer`
* This creates placeholder servers for testing purposes. These should be updated with their respective EC2 Instances
* The load-balancer uses a round-robin implementation

tsconfig.json
* 'module: ESNext' changed to "module: CommonJS"
* This fixed a crash caused by the "import http from 'http'"


`load-balancer running`
![image](https://github.com/user-attachments/assets/98f15c59-9a96-41c6-befd-b3d53d14c202)

`curl http://localhost:8080/search`
![image](https://github.com/user-attachments/assets/3bb22de0-6a18-487a-a89f-a2cdae8780a0)
